### PR TITLE
Teamwork Vanishing

### DIFF
--- a/Assets/Resources/Card Jsons/Getcha Getcha Getcha.json
+++ b/Assets/Resources/Card Jsons/Getcha Getcha Getcha.json
@@ -1,7 +1,7 @@
 {
 	"cardType":83,
 	"cardName":"Getcha Getcha Getcha",
-	"effText":"When a friendly character is augmented, give them +1N.",
+	"effText":"Comeback Play.\nWhen a friendly character is augmented, give them +1N.",
 	"effects":[
 		{
 			"triggerData":
@@ -26,7 +26,9 @@
 			]
 		}
 	],
+	"keywords":["Comeback Play"],
 	"c":1,
-	"spellType":"Enchant",
-	"subtypeText":"Sportsball Play Enchant"
+	"spellType":"Vanishing",
+	"arg":1,
+	"subtypeText":"Sportsball Play Vanishing"
 }

--- a/Assets/Resources/Card Jsons/Goal-Net Touchdown.json
+++ b/Assets/Resources/Card Jsons/Goal-Net Touchdown.json
@@ -1,7 +1,7 @@
 {
 	"cardType":83,
 	"cardName":"Goal-Net Touchdown",
-	"effText":"When a character moves adjacent to an enemy Avatar, apply their Augment(s) to an adjacent enemy Avatar.",
+	"effText":"Comeback Play.\nWhen a character moves adjacent to an enemy Avatar, apply their Augment(s) to an adjacent enemy Avatar.",
 	"effects":[
 		{
 			"triggerData":
@@ -56,7 +56,9 @@
 			]
 		}
 	],
+	"keywords":["Comeback Play"],
 	"c":1,
-	"spellType":"Enchant",
-	"subtypeText":"Sportsball Play Enchant"
+	"spellType":"Vanishing",
+	"arg":1,
+	"subtypeText":"Sportsball Play Vanishing"
 }

--- a/Assets/Resources/Card Jsons/Mad Jukes.json
+++ b/Assets/Resources/Card Jsons/Mad Jukes.json
@@ -47,36 +47,11 @@
 					"wMult":-1
 				}
 			]
-		},
-		{
-			"triggerData":
-			{
-				"blurb":"Sustain the Vuvuzelas",
-				"triggerCondition":"Turn Start",
-				"triggerRestriction":{
-					"triggerRestrictions":["This Card in Play"]
-				}
-			},
-			"subeffects":[
-				{
-					"$type":"KompasServer.Effects.ConditionalEndSubeffect, Assembly-CSharp",
-					"condition":"Any Fit Restriction",
-					"cardRestriction":
-					{
-						"cardRestrictions":["Subtypes Include","Friendly","Board","Is Augment"],
-						"subtypesInclude":["Sportsball"]
-					}
-				},
-				{
-					"$type":"KompasServer.Effects.TargetThisSubeffect, Assembly-CSharp"
-				},
-				{
-					"$type":"KompasServer.Effects.AnnihilateSubeffect, Assembly-CSharp"
-				}
-			]
 		}
 	],
+	"keywords":["Comeback Play"],
 	"c":1,
-	"spellType":"Enchant",
-	"subtypeText":"Sportsball Play Enchant"
+	"spellType":"Vanishing",
+	"arg":1,
+	"subtypeText":"Sportsball Play Vanishing"
 }

--- a/Assets/Resources/Card Jsons/Teamwork!.json
+++ b/Assets/Resources/Card Jsons/Teamwork!.json
@@ -1,7 +1,7 @@
 {
 	"cardType":83,
 	"cardName":"Teamwork!",
-	"effText":"The first time each stack a friendly character is augmented, draw 1.",
+	"effText":"Comeback Play.\nThe first time each stack a friendly character is augmented, draw 1.",
 	"effects":[
 		{
 			"triggerData":
@@ -22,11 +22,9 @@
 			]
 		}
 	],
+	"keywords":["Comeback Play"],
 	"c":1,
-	"PlayRestriction":{
-		"normalRestrictions":["Default Normal Restrictions"],
-		"effectRestrictions":["Default Effect Restrictions"]
-	},
-	"spellType":"Enchant",
-	"subtypeText":"Sportsball Play Enchant"
+	"spellType":"Vanishing",
+	"arg":1,
+	"subtypeText":"Sportsball Play Vanishing"
 }

--- a/Assets/Resources/Card Jsons/Whats Gonna Work.json
+++ b/Assets/Resources/Card Jsons/Whats Gonna Work.json
@@ -23,17 +23,15 @@
 					}
 				},
 				{
-					"$type":"KompasServer.Effects.AutoTargetSubeffect, Assembly-CSharp",
-					"cardRestriction":{
-						"cardRestrictions":["Avatar","Friendly"]
+					"$type":"KompasServer.Effects.SpaceTargetSubeffect, Assembly-CSharp",
+					"spaceRestriction":
+					{
+						"blurb":"where to make a Comeback Play",
+						"spaceRestrictions":["Can Play Target to This Space"]
 					}
 				},
 				{
-					"$type":"KompasServer.Effects.TargetTargetsSpaceSubeffect, Assembly-CSharp"
-				},
-				{
-					"$type":"KompasServer.Effects.PlaySubeffect, Assembly-CSharp",
-					"targetIndex":-2
+					"$type":"KompasServer.Effects.PlaySubeffect, Assembly-CSharp"
 				}
 			]	
 		}

--- a/Assets/Resources/Keyword Jsons/Comeback Play.json
+++ b/Assets/Resources/Keyword Jsons/Comeback Play.json
@@ -1,0 +1,35 @@
+{
+	"blurb":"Comeback Play",
+	"triggerData":
+	{
+		"blurb":"Comeback Play",
+		"triggerCondition":"Turn Start",
+		"triggerRestriction":{
+			"triggerRestrictions":["Friendly Turn","This Card Fits Restriction","Card Exists"],
+			"cardRestriction":{
+				"cardRestrictions":["Discard"]
+			},
+			"existsRestriction":
+			{
+				"cardRestrictions":["Friendly","Board","Is Augment","Subtypes Include"],
+				"subtypesInclude":["Sportsball"]
+			}
+		}
+	},
+	"subeffects":[
+		{
+			"$type":"KompasServer.Effects.TargetThisSubeffect, Assembly-CSharp"
+		},
+		{
+			"$type":"KompasServer.Effects.SpaceTargetSubeffect, Assembly-CSharp",
+			"spaceRestriction":
+			{
+				"blurb":"where to make a Comeback Play",
+				"spaceRestrictions":["Can Play Target to This Space"]
+			}
+		},
+		{
+			"$type":"KompasServer.Effects.PlaySubeffect, Assembly-CSharp"
+		}
+	]	
+}

--- a/Assets/Resources/Keyword Jsons/Comeback Play.json.meta
+++ b/Assets/Resources/Keyword Jsons/Comeback Play.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 69f96daaf33f76f4896c4c1783cdcea4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Keyword Jsons/Keyword List.txt
+++ b/Assets/Resources/Keyword Jsons/Keyword List.txt
@@ -8,3 +8,4 @@ Recoverable
 Territorial
 Machinations Play
 Machinations Reup
+Comeback Play

--- a/Assets/Scripts/Server/Card/ServerGameCard.cs
+++ b/Assets/Scripts/Server/Card/ServerGameCard.cs
@@ -127,7 +127,7 @@ namespace KompasServer.Cards
             base.Remove(stackSrc);
 
             //copy the colleciton  so that you can edit the original
-            var augments = Augments.ToArray();
+            var augments = AugmentsList.ToArray();
             foreach (var aug in augments) aug.Discard(stackSrc);
             return true;
         }

--- a/Assets/Scripts/Server/Effects/Targeting/TargetAugmentsSubeffect.cs
+++ b/Assets/Scripts/Server/Effects/Targeting/TargetAugmentsSubeffect.cs
@@ -18,10 +18,10 @@ namespace KompasServer.Effects
 
         public override bool Resolve()
         {
-            if (Target == null || !Target.Augments.Any(c => cardRestriction.Evaluate(c)))
+            if (Target == null || !Target.AugmentsList.Any(c => cardRestriction.Evaluate(c)))
                 return ServerEffect.EffectImpossible();
 
-            var potentialTargets = Target.Augments.Where(c => cardRestriction.Evaluate(c));
+            var potentialTargets = Target.AugmentsList.Where(c => cardRestriction.Evaluate(c));
             foreach(var c in potentialTargets) ServerEffect.AddTarget(c);
             return ServerEffect.ResolveNextSubeffect();
         }

--- a/Assets/Scripts/Server/Effects/Targeting/TargetTriggeringCardSubeffect.cs
+++ b/Assets/Scripts/Server/Effects/Targeting/TargetTriggeringCardSubeffect.cs
@@ -4,10 +4,10 @@
     {
         public override bool Resolve()
         {
-            if (ServerEffect.CurrActivationContext.Card == null)
+            if (ServerEffect.CurrActivationContext.CardInfo == null)
                 return ServerEffect.EffectImpossible();
 
-            ServerEffect.AddTarget(ServerEffect.CurrActivationContext.Card);
+            ServerEffect.AddTarget(ServerEffect.CurrActivationContext.CardInfo.Card);
             return ServerEffect.ResolveNextSubeffect();
         }
     }

--- a/Assets/Scripts/Server/ServerAnnihilationController.cs
+++ b/Assets/Scripts/Server/ServerAnnihilationController.cs
@@ -10,20 +10,12 @@ namespace KompasServer.GameCore
 
         public override bool Annihilate(GameCard card, IStackable stackSrc = null)
         {
-            if (card.CanRemove)
+            var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: stackSrc?.Controller);
+            bool wasKnown = card.KnownToEnemy;
+            if (base.Annihilate(card, stackSrc))
             {
-                var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: stackSrc?.Controller);
                 ServerGame.EffectsController.TriggerForCondition(Trigger.Annhilate, context);
-                ServerGame.ServerPlayers[card.ControllerIndex].ServerNotifier.NotifyAnnhilate(card);
-                return base.Annihilate(card, stackSrc);
-            }
-            return false;
-        }
-
-        public override bool Remove(GameCard card)
-        {
-            if (base.Remove(card))
-            {
+                ServerGame.ServerPlayers[card.ControllerIndex].ServerNotifier.NotifyAnnhilate(card, wasKnown);
                 card.ResetCard();
                 return true;
             }

--- a/Assets/Scripts/Server/ServerBoardController.cs
+++ b/Assets/Scripts/Server/ServerBoardController.cs
@@ -15,13 +15,14 @@ namespace KompasServer.GameCore
 
         public override bool Play(GameCard toPlay, int toX, int toY, Player controller, IStackable stackSrc = null)
         {
-            if (toPlay.CanRemove)
+            var context = new ActivationContext(card: toPlay, stackable: stackSrc, triggerer: controller, space: (toX, toY));
+            bool wasKnown = toPlay.KnownToEnemy;
+            if (base.Play(toPlay, toX, toY, controller))
             {
-                var context = new ActivationContext(card: toPlay, stackable: stackSrc, triggerer: controller, space: (toX, toY));
                 EffectsController.TriggerForCondition(Trigger.Play, context);
                 EffectsController.TriggerForCondition(Trigger.Arrive, context);
-                if (!toPlay.IsAvatar) ServerNotifierByIndex(toPlay.ControllerIndex).NotifyPlay(toPlay, toX, toY);
-                return base.Play(toPlay, toX, toY, controller);
+                if (!toPlay.IsAvatar) ServerNotifierByIndex(toPlay.ControllerIndex).NotifyPlay(toPlay, toX, toY, wasKnown);
+                return true;
             }
             return false;
         }

--- a/Assets/Scripts/Server/ServerDeckController.cs
+++ b/Assets/Scripts/Server/ServerDeckController.cs
@@ -18,49 +18,51 @@ namespace KompasServer.GameCore
 
         protected override bool AddCard(GameCard card, IStackable stackSrc = null)
         {
-            if (card.CanRemove)
+            var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
+            if (base.AddCard(card))
             {
-                var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
                 EffectsController.TriggerForCondition(Trigger.ToDeck, context);
-                var success = base.AddCard(card);
                 owner.ServerNotifier.NotifyDeckCount(Deck.Count);
-                return success;
+                return true;
             }
             return false;
         }
 
         public override bool PushBottomdeck(GameCard card, IStackable stackSrc = null)
         {
-            if (card.CanRemove)
+            var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
+            bool wasKnown = card.KnownToEnemy;
+            if (base.PushBottomdeck(card, stackSrc))
             {
-                var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
                 EffectsController.TriggerForCondition(Trigger.Bottomdeck, context);
-                ServerNotifier.NotifyBottomdeck(card);
-                return base.PushBottomdeck(card, stackSrc);
+                ServerNotifier.NotifyBottomdeck(card, wasKnown);
+                return true;
             }
             return false;
         }
 
         public override bool PushTopdeck(GameCard card, IStackable stackSrc = null)
         {
-            if (card.CanRemove)
+            var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
+            bool wasKnown = card.KnownToEnemy;
+            if (base.PushTopdeck(card, stackSrc))
             {
-                var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
                 EffectsController.TriggerForCondition(Trigger.Topdeck, context);
-                ServerNotifier.NotifyTopdeck(card);
-                return base.PushTopdeck(card, stackSrc);
+                ServerNotifier.NotifyTopdeck(card, wasKnown);
+                return true;
             }
             return false;
         }
 
         public override bool ShuffleIn(GameCard card, IStackable stackSrc = null)
         {
-            if (card.CanRemove)
+            var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
+            bool wasKnown = card.KnownToEnemy;
+            if (base.ShuffleIn(card, stackSrc))
             {
-                var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
                 EffectsController.TriggerForCondition(Trigger.Reshuffle, context);
-                ServerNotifier.NotifyReshuffle(card);
-                return base.ShuffleIn(card, stackSrc);
+                ServerNotifier.NotifyReshuffle(card, wasKnown);
+                return true;
             }
             return false;
         }

--- a/Assets/Scripts/Server/ServerDiscardController.cs
+++ b/Assets/Scripts/Server/ServerDiscardController.cs
@@ -15,13 +15,16 @@ namespace KompasServer.GameCore
 
         public override bool AddToDiscard(GameCard card, IStackable stackSrc = null)
         {
-            if (!card.CanRemove) return false;
             var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
-            EffectsController.TriggerForCondition(Trigger.Discard, context);
-            ServerNotifier.NotifyDiscard(card);
-            bool success = base.AddToDiscard(card);
-            if (success) card.ResetCard();
-            return success;
+            bool wasKnown = card.KnownToEnemy;
+            if (base.AddToDiscard(card, stackSrc))
+            {
+                EffectsController.TriggerForCondition(Trigger.Discard, context);
+                ServerNotifier.NotifyDiscard(card, wasKnown);
+                card.ResetCard();
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/Assets/Scripts/Server/ServerDiscardController.cs
+++ b/Assets/Scripts/Server/ServerDiscardController.cs
@@ -19,17 +19,9 @@ namespace KompasServer.GameCore
             var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
             EffectsController.TriggerForCondition(Trigger.Discard, context);
             ServerNotifier.NotifyDiscard(card);
-            return base.AddToDiscard(card);
-        }
-
-        public override bool RemoveFromDiscard(GameCard card)
-        {
-            if(base.RemoveFromDiscard(card))
-            {
-                card.ResetCard();
-                return true;
-            }
-            return false;
+            bool success = base.AddToDiscard(card);
+            if (success) card.ResetCard();
+            return success;
         }
     }
 }

--- a/Assets/Scripts/Server/ServerGame.cs
+++ b/Assets/Scripts/Server/ServerGame.cs
@@ -153,7 +153,7 @@ namespace KompasServer.GameCore
                 }
                 player.deckCtrl.ShuffleIn(card);
                 if (card != null) Debug.Log($"Adding new card {card.CardName} with id {card.ID}");
-                player.ServerNotifier.NotifyAddToDeck(card);
+                player.ServerNotifier.NotifyAddToDeck(card, wasKnown: false);
             }
 
             Debug.Log($"Setting avatar for player {player.index}");
@@ -203,9 +203,12 @@ namespace KompasServer.GameCore
                 var toDraw = controller.deckCtrl.Topdeck;
                 if (toDraw == null) break;
                 var eachDrawContext = new ActivationContext(card: toDraw, stackable: stackSrc, triggerer: controller);
-                EffectsController.TriggerForCondition(Trigger.EachDraw, eachDrawContext);
-                toDraw.Rehand(controller, stackSrc);
-                drawn.Add(toDraw);
+                if (toDraw.Rehand(controller, stackSrc))
+                {
+                    EffectsController.TriggerForCondition(Trigger.EachDraw, eachDrawContext);
+                    drawn.Add(toDraw);
+                }
+                else break;
             }
             var context = new ActivationContext(stackable: stackSrc, triggerer: controller, x: i);
             EffectsController.TriggerForCondition(Trigger.DrawX, context);

--- a/Assets/Scripts/Server/ServerHandController.cs
+++ b/Assets/Scripts/Server/ServerHandController.cs
@@ -15,13 +15,16 @@ namespace KompasServer.GameCore
 
         public override bool AddToHand(GameCard card, IStackable stackSrc = null)
         {
-            if (!card.CanRemove) return false;
             var context = new ActivationContext(card: card, stackable: stackSrc, triggerer: Owner);
-            EffectsController.TriggerForCondition(Trigger.Rehand, context);
-            ServerNotifier.NotifyRehand(card);
-            bool success = base.AddToHand(card);
-            if(success) card.ResetCard();
-            return success;
+            bool wasKnown = card.KnownToEnemy;
+            if (base.AddToHand(card, stackSrc))
+            {
+                EffectsController.TriggerForCondition(Trigger.Rehand, context);
+                ServerNotifier.NotifyRehand(card, wasKnown);
+                card.ResetCard();
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/Assets/Scripts/Shared/BoardController.cs
+++ b/Assets/Scripts/Shared/BoardController.cs
@@ -89,7 +89,7 @@ namespace KompasCore.GameCore
             foreach(var card in Board)
             {
                 if (predicate(card)) list.Add(card);
-                if (card != null) list.AddRange(card.Augments.Where(predicate));
+                if (card != null) list.AddRange(card.AugmentsList.Where(predicate));
             }
             return list;
         }

--- a/Assets/Scripts/Shared/BoardController.cs
+++ b/Assets/Scripts/Shared/BoardController.cs
@@ -187,7 +187,6 @@ namespace KompasCore.GameCore
             }
 
             Debug.Log($"In boardctrl, playing {toPlay.CardName} to {toX}, {toY}");
-            toPlay.Remove(stackSrc);
 
             //augments can't be played to a regular space.
             if (toPlay.CardType == 'A')
@@ -195,13 +194,18 @@ namespace KompasCore.GameCore
                 //augments therefore just get put on whatever card is on that space rn.
                 var augmented = Board[toX, toY];
                 //if there isn't a card, well, you can't do that.
-                if (augmented == null) return false;
+                if (augmented == null)
+                {
+                    Debug.LogError($"Can't play an augment to empty space at {toX}, {toY}");
+                    return false;
+                }
                 //assuming there is a card there, try and add the augment. if it don't work, it borked.
                 if (!Board[toX, toY].AddAugment(toPlay, stackSrc)) return false;
             }
             //otherwise, put a card to the requested space
             else
             {
+                toPlay.Remove(stackSrc);
                 Board[toX, toY] = toPlay;
                 toPlay.Location = CardLocation.Field;
                 toPlay.Position = (toX, toY);

--- a/Assets/Scripts/Shared/Card/CardController.cs
+++ b/Assets/Scripts/Shared/Card/CardController.cs
@@ -158,7 +158,7 @@ namespace KompasCore.Cards
 
         public void SpreadOutAugs()
         {
-            var augCount = card.Augments.Count;
+            var augCount = card.AugmentsList.Count;
             /*float scale = 0.4f / ((float) (augCount / 4));
             float increment = 0.4f/ ((float) (augCount / 4)); //1f / ((float) (2f * augCount))
             float xOffset = -1f + increment;
@@ -172,7 +172,7 @@ namespace KompasCore.Cards
             }*/
             float scale = 0.4f / ((float)((augCount + 3) / 4));
             int i = 0;
-            foreach(var aug in card.Augments)
+            foreach(var aug in card.AugmentsList)
             {
                 aug.transform.parent = card.transform;
                 aug.transform.localScale = new Vector3(scale, scale, scale);
@@ -290,7 +290,7 @@ namespace KompasCore.Cards
         /// </summary>
         private void MoveTo((int x, int y) to)
         {
-            int heightIndex = card.AugmentedCard == null ? card.Augments.Count : card.AugmentedCard.Augments.IndexOf(card);
+            int heightIndex = card.AugmentedCard == null ? card.AugmentsList.Count : card.AugmentedCard.AugmentsList.IndexOf(card);
             transform.localPosition = BoardController.GridIndicesToPosWithStacking(to.x, to.y, heightIndex);
             gameObject.SetActive(card.AugmentedCard == null);
 

--- a/Assets/Scripts/Shared/Card/GameCard.cs
+++ b/Assets/Scripts/Shared/Card/GameCard.cs
@@ -121,6 +121,7 @@ namespace KompasCore.Cards
                     case CardLocation.Field: return BoardX * 7 + BoardY;
                     case CardLocation.Hand: return Controller.handCtrl.IndexOf(this);
                     case CardLocation.Annihilation: return Game.annihilationCtrl.Cards.IndexOf(this);
+                    case CardLocation.Nowhere: return -1;
                     default:
                         Debug.LogError($"Tried to ask for card index when in location {Location}");
                         return -1;
@@ -191,7 +192,7 @@ namespace KompasCore.Cards
             get => location;
             set
             {
-                Debug.Log($"Card {ID} location set to {value}");
+                Debug.Log($"Card {ID} named {CardName} location set to {value}");
                 location = value;
                 if (cardCtrl == null) Debug.LogWarning($"Missing a card control. Is this a debug card?");
                 else cardCtrl.SetPhysicalLocation(location);
@@ -366,14 +367,23 @@ namespace KompasCore.Cards
         public virtual bool AddAugment(GameCard augment, IStackable stackSrc = null)
         {
             //can't add a null augment
-            if (augment == null) return false;
+            if (augment == null)
+            {
+                Debug.LogError($"Can't add a null augment.");
+                return false;
+            }
 
             //if this and the other are in the same place, it doesn't leave play
             bool canHappen = false;
             if (augment.Location != Location) canHappen = augment.Remove(stackSrc);
             else if (augment.AugmentedCard != null) canHappen = augment.Detach(stackSrc);
 
-            if (!canHappen) return false;
+            if (!canHappen)
+            {
+                Debug.LogError($"Couldn't remove or detach augment from {augment.Location} while this in {Location}," +
+                    $" or {augment.AugmentedCard?.CardName}");
+                return false;
+            }
 
             //regardless, add the augment
             AugmentsList.Add(augment);

--- a/Assets/Scripts/Shared/Card/GameCardInfo.cs
+++ b/Assets/Scripts/Shared/Card/GameCardInfo.cs
@@ -1,0 +1,192 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace KompasCore.Cards
+{
+    public interface IGameCardInfo
+    {
+        public GameCard Card { get; }
+        public CardLocation Location { get; }
+        public int IndexInList { get; }
+        public string CardName { get; }
+        public char CardType { get; }
+        public Player Controller { get; }
+        public Player Owner { get; }
+        public bool Summoned { get; }
+        public bool IsAvatar { get; }
+        public string SubtypeText { get; }
+        public GameCard AugmentedCard { get; }
+        public IEnumerable<GameCard> Augments { get; }
+
+        public int N { get; }
+        public int E { get; }
+        public int S { get; }
+        public int W { get; }
+        public int C { get; }
+        public int A { get; }
+        public int Cost { get; }
+
+        public bool Negated { get; }
+        public IEnumerable<GameCard> AdjacentCards { get; }
+
+        public (int x, int y) Position { get; }
+
+        public int DistanceTo(int x, int y);
+        public int DistanceTo(IGameCardInfo card);
+        public bool IsAdjacentTo(IGameCardInfo card);
+        public bool SameColumn(IGameCardInfo card);
+        public bool WithinSpaces(int spaces, IGameCardInfo card);
+    }
+
+    /// <summary>
+    /// Holds the info for a card at a given snapshot in time.
+    /// Used for triggers.
+    /// </summary>
+    public class GameCardInfo : IGameCardInfo
+    {
+        public GameCard Card { get; }
+        public char CardType { get; }
+        public string SpellSubtype { get; }
+        public int Arg { get; }
+
+        public CardLocation Location { get; }
+        public int IndexInList { get; }
+        public string CardName { get; }
+        public Player Controller { get; }
+        public Player Owner { get; }
+        public bool Summoned { get; }
+        public bool IsAvatar { get; }
+        public string SubtypeText { get; }
+        public GameCard AugmentedCard { get; }
+        public IEnumerable<GameCard> Augments { get; }
+
+        public int N { get; }
+        public int E { get; }
+        public int S { get; }
+        public int W { get; }
+        public int C { get; }
+        public int A { get; }
+        public int Cost { get; }
+
+        public bool Negated { get; }
+        public IEnumerable<GameCard> AdjacentCards { get; }
+
+        public (int x, int y) Position { get; }
+        public (int x, int y) SubjectivePosition => Controller.SubjectiveCoords(Position);
+
+        public GameCardInfo(GameCard card)
+        {
+            Card = card;
+            Location = card.Location;
+            IndexInList = card.IndexInList;
+            CardName = card.CardName;
+            CardType = card.CardType;
+            SpellSubtype = card.SpellSubtype;
+            Arg = card.Arg;
+            Controller = card.Controller;
+            Owner = card.Owner;
+            Summoned = card.Summoned;
+            IsAvatar = card.IsAvatar;
+            SubtypeText = card.SubtypeText;
+            AugmentedCard = card.AugmentedCard;
+            Augments = card.Augments.ToArray();
+            N = card.N;
+            E = card.E;
+            S = card.S;
+            W = card.W;
+            C = card.C;
+            A = card.A;
+            Cost = card.Cost;
+            Negated = card.Negated;
+            AdjacentCards = card.AdjacentCards.ToArray();
+            Position = card.Position;
+        }
+
+        #region distance/adjacency
+        public int DistanceTo(int x, int y)
+        {
+            if (Location != CardLocation.Field) return int.MaxValue;
+            return Mathf.Abs(x - Position.x) > Mathf.Abs(y - Position.y) ? Mathf.Abs(x - Position.x) : Mathf.Abs(y - Position.y);
+            /* equivalent to
+             * if (Mathf.Abs(card.X - X) > Mathf.Abs(card.Y - Y)) return Mathf.Abs(card.X - X);
+             * else return Mathf.Abs(card.Y - Y);
+             * is card.X - X > card.Y - Y? If so, return card.X -X, otherwise return card.Y - Y
+            */
+        }
+        public int DistanceTo((int x, int y) space) => DistanceTo(space.x, space.y);
+        public int DistanceTo(IGameCardInfo card) => DistanceTo(card.Position);
+        public bool WithinSpaces(int numSpaces, IGameCardInfo card)
+            => card != null && card.Location == CardLocation.Field && Location == CardLocation.Field && DistanceTo(card) <= numSpaces;
+        public bool WithinSpaces(int numSpaces, int x, int y) => DistanceTo(x, y) <= numSpaces;
+        public bool IsAdjacentTo(IGameCardInfo card) => Location == CardLocation.Field && card != null
+            && card.Location == CardLocation.Field && DistanceTo(card) == 1;
+        public bool IsAdjacentTo(int x, int y) => Location == CardLocation.Field && DistanceTo(x, y) == 1;
+        public bool CardInAOE(IGameCardInfo c) => SpaceInAOE(c.Position);
+        public bool SpaceInAOE((int x, int y) space) => SpaceInAOE(space.x, space.y);
+        public bool SpaceInAOE(int x, int y)
+            => CardType == 'S' && SpellSubtype == CardBase.RadialSubtype && DistanceTo(x, y) <= Arg;
+        public bool SameColumn(int x, int y) => Position.x - Position.y == x - y;
+        public bool SameColumn(IGameCardInfo c) => c.Location == CardLocation.Field && SameColumn(c.Position.x, c.Position.y);
+
+        /// <summary>
+        /// Returns whether the <paramref name="space"/> passed in is in front of this card
+        /// </summary>
+        /// <param name="space">The space to check if it's in front of this card</param>
+        /// <returns><see langword="true"/> if <paramref name="space"/> is in front of this, <see langword="false"/> otherwise.</returns>
+        public bool SpaceInFront((int x, int y) space) => Controller.SubjectiveCoord(space.x) > SubjectivePosition.x;
+
+        /// <summary>
+        /// Returns whether the card passed in is in front of this card
+        /// </summary>
+        /// <param name="card">The card to check if it's in front of this one</param>
+        /// <returns><see langword="true"/> if <paramref name="card"/> is in front of this, <see langword="false"/> otherwise.</returns>
+        public bool CardInFront(IGameCardInfo card) => SpaceInFront(card.Position);
+
+        /// <summary>
+        /// Returns whether the <paramref name="space"/> passed in is behind this card
+        /// </summary>
+        /// <param name="space">The space to check if it's behind this card</param>
+        /// <returns><see langword="true"/> if <paramref name="space"/> is behind this, <see langword="false"/> otherwise.</returns>
+        public bool SpaceBehind((int x, int y) space) => Controller.SubjectiveCoord(space.x) < SubjectivePosition.x;
+
+        /// <summary>
+        /// Returns whether the card passed in is behind this card
+        /// </summary>
+        /// <param name="card">The card to check if it's behind this one</param>
+        /// <returns><see langword="true"/> if <paramref name="card"/> is behind this, <see langword="false"/> otherwise.</returns>
+        public bool CardBehind(IGameCardInfo card) => SpaceBehind(card.Position);
+
+        public bool SpaceDirectlyInFront((int x, int y) space)
+            => Controller.SubjectiveCoords(space) == (SubjectivePosition.x + 1, SubjectivePosition.y + 1);
+
+        public bool CardDirectlyInFront(IGameCardInfo card)
+            => Location == CardLocation.Field && card.Location == CardLocation.Field && SpaceDirectlyInFront(card.Position);
+
+        public bool OnMyDiagonal((int x, int y) space) => Location == CardLocation.Field && (Position.x == space.x || Position.y == space.y);
+
+        /// <summary>
+        /// Refers to this situation: <br></br>
+        /// | <paramref name="space"/> | <br></br>
+        /// | this card | <br></br>
+        /// | <paramref name="card"/> param | <br></br>
+        /// </summary>
+        /// <param name="space">The space in the same axis as this card and <paramref name="card"/> param</param>
+        /// <param name="card">The card in the same axis as this card and the <paramref name="space"/> param.</param>
+        /// <returns></returns>
+        public bool SpaceDirectlyAwayFrom((int x, int y) space, IGameCardInfo card)
+        {
+            if (card.Location != CardLocation.Field || Location != CardLocation.Field) return false;
+            int xDiffCard = card.Position.x - Position.x;
+            int yDiffCard = card.Position.y - Position.y;
+            int xDiffSpace = space.x - Position.x;
+            int yDiffSpace = space.y - Position.y;
+
+            return (xDiffCard == 0 && xDiffSpace == 0)
+                || (yDiffCard == 0 && yDiffSpace == 0)
+                || (xDiffCard == yDiffCard && xDiffSpace == yDiffSpace);
+        }
+        #endregion distance/adjacency
+    }
+}

--- a/Assets/Scripts/Shared/Card/GameCardInfo.cs
+++ b/Assets/Scripts/Shared/Card/GameCardInfo.cs
@@ -7,37 +7,37 @@ namespace KompasCore.Cards
 {
     public interface IGameCardInfo
     {
-        public GameCard Card { get; }
-        public CardLocation Location { get; }
-        public int IndexInList { get; }
-        public string CardName { get; }
-        public char CardType { get; }
-        public Player Controller { get; }
-        public Player Owner { get; }
-        public bool Summoned { get; }
-        public bool IsAvatar { get; }
-        public string SubtypeText { get; }
-        public GameCard AugmentedCard { get; }
-        public IEnumerable<GameCard> Augments { get; }
+        GameCard Card { get; }
+        CardLocation Location { get; }
+        int IndexInList { get; }
+        string CardName { get; }
+        char CardType { get; }
+        Player Controller { get; }
+        Player Owner { get; }
+        bool Summoned { get; }
+        bool IsAvatar { get; }
+        string SubtypeText { get; }
+        GameCard AugmentedCard { get; }
+        IEnumerable<GameCard> Augments { get; }
 
-        public int N { get; }
-        public int E { get; }
-        public int S { get; }
-        public int W { get; }
-        public int C { get; }
-        public int A { get; }
-        public int Cost { get; }
+        int N { get; }
+        int E { get; }
+        int S { get; }
+        int W { get; }
+        int C { get; }
+        int A { get; }
+        int Cost { get; }
 
-        public bool Negated { get; }
-        public IEnumerable<GameCard> AdjacentCards { get; }
+        bool Negated { get; }
+        IEnumerable<GameCard> AdjacentCards { get; }
 
-        public (int x, int y) Position { get; }
+        (int x, int y) Position { get; }
 
-        public int DistanceTo(int x, int y);
-        public int DistanceTo(IGameCardInfo card);
-        public bool IsAdjacentTo(IGameCardInfo card);
-        public bool SameColumn(IGameCardInfo card);
-        public bool WithinSpaces(int spaces, IGameCardInfo card);
+        int DistanceTo(int x, int y);
+        int DistanceTo(IGameCardInfo card);
+        bool IsAdjacentTo(IGameCardInfo card);
+        bool SameColumn(IGameCardInfo card);
+        bool WithinSpaces(int spaces, IGameCardInfo card);
     }
 
     /// <summary>

--- a/Assets/Scripts/Shared/Card/GameCardInfo.cs.meta
+++ b/Assets/Scripts/Shared/Card/GameCardInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c873038029af88e4c87def78ed61ea5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Shared/DeckController.cs
+++ b/Assets/Scripts/Shared/DeckController.cs
@@ -59,7 +59,11 @@ namespace KompasCore.GameCore
         /// </summary>
         public virtual bool RemoveFromDeck(GameCard card)
         {
-            if (!Deck.Contains(card)) return false;
+            if (!Deck.Contains(card))
+            {
+                Debug.LogError($"Couldn't remove {card.CardName} from deck, it wasn't in deck!");
+                return false;
+            }
 
             Deck.Remove(card);
             return true;

--- a/Assets/Scripts/Shared/Effects/ActivationContext.cs
+++ b/Assets/Scripts/Shared/Effects/ActivationContext.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace KompasCore.Effects
 {
-    public struct ActivationContext
+    public class ActivationContext
     {
-        public readonly GameCard Card;
+        public readonly IGameCardInfo CardInfo;
         public readonly IStackable Stackable;
         public readonly Player Triggerer;
         public readonly int? X;
@@ -17,20 +17,20 @@ namespace KompasCore.Effects
         public ActivationContext(GameCard card = null, IStackable stackable = null, Player triggerer = null,
             int? x = null, (int, int)? space = null, int startIndex = 0, List<GameCard> targets = null)
         {
-            Card = card;
+            CardInfo = card == null ? null : new GameCardInfo(card);
             Stackable = stackable;
             Triggerer = triggerer;
             X = x;
             Space = space;
             StartIndex = startIndex;
-            Targets = targets; //no use ??ing to a new list because there's the default parameterless constructor
+            Targets = targets;
         }
 
         public override string ToString()
         {
             var sb = new System.Text.StringBuilder();
 
-            sb.Append(Card == null ? "No triggering card, " : $"Card: {Card.CardName}, ");
+            sb.Append(CardInfo == null ? "No triggering card, " : $"Card: {CardInfo.CardName}, ");
             sb.Append(Stackable == null ? "No triggering stackable, " : $"Stackable from: {Stackable.Source.CardName}, ");
             sb.Append(Triggerer == null ? "No triggering player, " : $"Triggerer: {Triggerer.index}, ");
             sb.Append(X == null ? "No X, " : $"X: {X}, ");

--- a/Assets/Scripts/Shared/Effects/Restrictions/CardRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/CardRestriction.cs
@@ -140,6 +140,8 @@ namespace KompasCore.Effects
 
         public string blurb = "";
 
+        private bool initialized = false;
+
         public void Initialize(Subeffect subeff)
         {
             this.Subeffect = subeff;
@@ -153,6 +155,8 @@ namespace KompasCore.Effects
                 secondaryRestriction = JsonUtility.FromJson<CardRestriction>(secondaryRestrictionString);
                 secondaryRestriction.Initialize(subeff);
             }
+
+            initialized = true;
         }
 
         public void Initialize(GameCard source, Player controller, Effect eff)
@@ -160,6 +164,8 @@ namespace KompasCore.Effects
             Source = source;
             Controller = controller;
             Effect = eff;
+
+            initialized = true;
         }
 
         /// <summary>
@@ -193,6 +199,7 @@ namespace KompasCore.Effects
                 case NotAugment:  return potentialTarget.CardType != 'A';
 
                 //control
+                //Debug.Log($"potential target controller? {potentialTarget.Controller?.index}, my controller {Controller?.index}");
                 case Friendly:  return potentialTarget.Controller == Controller;
                 case Enemy:     return potentialTarget.Controller != Controller;
                 case SameOwner: return potentialTarget.Owner == Controller;
@@ -286,13 +293,13 @@ namespace KompasCore.Effects
         }
 
         /* This exists to debug a card restriction,
-         * but should not be usually used because it prints a ton 
-        public bool RestrictionValidDebug(string restriction, GameCard potentialTarget, int x)
+         * but should not be usually used because it prints a ton */
+        public bool RestrictionValidDebug(string restriction, IGameCardInfo potentialTarget, int x)
         {
             bool answer = RestrictionValid(restriction, potentialTarget, x);
-            // if (!answer) Debug.Log($"{potentialTarget.CardName} flouts {restriction}");
+            if (!answer) Debug.Log($"{potentialTarget.CardName} flouts {restriction}");
             return answer;
-        } */
+        }
 
         /// <summary>
         /// Checks whether the card in question fits the relevant retrictions, for the given value of X
@@ -302,6 +309,8 @@ namespace KompasCore.Effects
         /// <returns><see langword="true"/> if the card fits all restrictions, <see langword="false"/> if it doesn't fit at least one</returns>
         public bool Evaluate(IGameCardInfo potentialTarget, int x)
         {
+            if (!initialized) throw new ArgumentException("Card restriction not initialized!");
+
             if (potentialTarget == null) return false;
 
             return cardRestrictions.All(r => RestrictionValid(r, potentialTarget, x));

--- a/Assets/Scripts/Shared/Effects/Restrictions/CardRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/CardRestriction.cs
@@ -169,7 +169,7 @@ namespace KompasCore.Effects
         /// <param name="potentialTarget">The card to consider the restriction for.</param>
         /// <param name="x">The value of x for which to consider the restriction</param>
         /// <returns><see langword="true"/> if the card fits the restriction for the given value of x, <see langword="false"/> otherwise.</returns>
-        private bool RestrictionValid(string restriction, GameCard potentialTarget, int x)
+        private bool RestrictionValid(string restriction, IGameCardInfo potentialTarget, int x)
         {
             if (potentialTarget == null) return false;
 
@@ -210,14 +210,14 @@ namespace KompasCore.Effects
                 case SubtypesExclude: return subtypesExclude.All(s => !potentialTarget.SubtypeText.Contains(s));
 
                 //is
-                case IsSource: return potentialTarget == Source;
+                case IsSource: return potentialTarget.Card == Source;
                 case AugmentsTarget: return potentialTarget.AugmentedCard == Subeffect.Target;
                 case WieldsAugmentFittingRestriction: return potentialTarget.Augments.Any(c => secondaryRestriction.Evaluate(c));
 
                 //distinct
-                case DistinctFromSource: return potentialTarget != Source;
-                case DistinctFromTarget: return potentialTarget != Subeffect.Target;
-                case DistinctFromAugmentedCard: return potentialTarget != Source.AugmentedCard;
+                case DistinctFromSource: return potentialTarget.Card != Source;
+                case DistinctFromTarget: return potentialTarget.Card != Subeffect.Target;
+                case DistinctFromAugmentedCard: return potentialTarget.Card != Source.AugmentedCard;
 
                 //location
                 case Hand:           return potentialTarget.Location == CardLocation.Hand;
@@ -277,10 +277,10 @@ namespace KompasCore.Effects
                 case EffectControllerCanPayCost: return Subeffect.Effect.Controller.Pips >= potentialTarget.Cost * costMultiplier / costDivisor;
                 case Augmented: return potentialTarget.Augments.Any();
                 case IsDefendingFromSource:
-                    return Source.Game.StackEntries.Any(s => s is Attack atk && atk.attacker == Source && atk.defender == potentialTarget)
-                        || (Source.Game.CurrStackEntry is Attack atk2 && atk2.attacker == Source && atk2.defender == potentialTarget);
+                    return Source.Game.StackEntries.Any(s => s is Attack atk && atk.attacker == Source && atk.defender == potentialTarget.Card)
+                        || (Source.Game.CurrStackEntry is Attack atk2 && atk2.attacker == Source && atk2.defender == potentialTarget.Card);
                 case CanPlayTargetToThisCharactersSpace:
-                    return Subeffect.Target.PlayRestriction.EvaluateEffectPlay(potentialTarget.BoardX, potentialTarget.BoardY, Effect);
+                    return Subeffect.Target.PlayRestriction.EvaluateEffectPlay(potentialTarget.Position.x, potentialTarget.Position.y, Effect);
                 default: throw new ArgumentException($"Invalid card restriction {restriction}", "restriction");
             }
         }
@@ -300,7 +300,7 @@ namespace KompasCore.Effects
         /// <param name="potentialTarget">The card to see if it fits all restrictions</param>
         /// <param name="x">The value of X for which to consider this effect's restriction</param>
         /// <returns><see langword="true"/> if the card fits all restrictions, <see langword="false"/> if it doesn't fit at least one</returns>
-        public bool Evaluate(GameCard potentialTarget, int x)
+        public bool Evaluate(IGameCardInfo potentialTarget, int x)
         {
             if (potentialTarget == null) return false;
 
@@ -312,6 +312,6 @@ namespace KompasCore.Effects
         /// </summary>
         /// <param name="potentialTarget">The card to see if it fits all restrictions</param>
         /// <returns><see langword="true"/> if the card fits all restrictions, <see langword="false"/> if it doesn't fit at least one</returns>
-        public bool Evaluate(GameCard potentialTarget) => Evaluate(potentialTarget, Subeffect?.Count ?? 0);
+        public bool Evaluate(IGameCardInfo potentialTarget) => Evaluate(potentialTarget, Subeffect?.Count ?? 0);
     }
 }

--- a/Assets/Scripts/Shared/Effects/Restrictions/SpaceRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/SpaceRestriction.cs
@@ -51,6 +51,8 @@ namespace KompasCore.Effects
         public string blurb = "";
         public bool mustBeEmpty = true;
 
+        private bool initialized = false;
+
         public void Initialize(GameCard source, Player controller, Effect effect)
         {
             Source = source;
@@ -66,6 +68,8 @@ namespace KompasCore.Effects
             connectednessRestriction.Initialize(source, controller, effect);
             limitAdjacencyRestriction.Initialize(source, controller, effect);
             hereFitsRestriction.Initialize(source, controller, effect);
+
+            initialized = true;
         }
 
         public void Initialize(Subeffect subeffect)
@@ -116,6 +120,7 @@ namespace KompasCore.Effects
 
         public bool Evaluate(int x, int y)
         {
+            if (!initialized) throw new System.ArgumentException("Space restriction not initialized!");
             if (!Source.Game.boardCtrl.ValidIndices(x, y)) return false;
             if (mustBeEmpty && Source.Game.boardCtrl.GetCardAt(x, y) != null) return false;
 

--- a/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
@@ -94,19 +94,19 @@ namespace KompasCore.Effects
             switch (restriction)
             {
                 //card triggering stuff
-                case ThisCardTriggered:        return context.Card == ThisCard;
+                case ThisCardTriggered:        return context.CardInfo.Card == ThisCard;
                 case ThisCardInPlay:           return ThisCard.Location == CardLocation.Field;
-                case AugmentedCardTriggered:   return context.Card == ThisCard.AugmentedCard;
+                case AugmentedCardTriggered:   return context.CardInfo.Card == ThisCard.AugmentedCard;
                 case CardExists:               return ThisCard.Game.Cards.Any(c => existsRestriction.Evaluate(c));
                 case ThisCardFitsRestriction:  return cardRestriction.Evaluate(ThisCard);
-                case TriggererFitsRestriction: return cardRestriction.Evaluate(context.Card);
-                case TriggerersAugmentedCardFitsRestriction: return cardRestriction.Evaluate(context.Card.AugmentedCard);
+                case TriggererFitsRestriction: return cardRestriction.Evaluate(context.CardInfo);
+                case TriggerersAugmentedCardFitsRestriction: return cardRestriction.Evaluate(context.CardInfo.AugmentedCard);
                 case StackableSourceFitsRestriction: return sourceRestriction.Evaluate(context.Stackable?.Source);
                 
                 //other non-card triggering things
                 case CoordsFitRestriction:    return context.Space != null && spaceRestriction.Evaluate(context.Space.Value);
                 case XFitsRestriction:        return context.X != null && xRestriction.Evaluate(context.X.Value);
-                case EffectSourceIsTriggerer: return context.Stackable is Effect eff && eff.Source == context.Card;
+                case EffectSourceIsTriggerer: return context.Stackable is Effect eff && eff.Source == context.CardInfo.Card;
                 case AdjacentToRestriction:   return ThisCard.AdjacentCards.Any(c => cardRestriction.Evaluate(c));
                 //TODO make these into just something to do with triggered card fitting restriction
                 case ControllerTriggered:     return context.Triggerer == ThisCard.Controller;
@@ -114,13 +114,14 @@ namespace KompasCore.Effects
 
                 case DistanceTriggererToSpaceConstant:
                     if (context.Space == null) return false;
-                    return context.Card.DistanceTo(context.Space.Value) == distance;
+                    var (x, y) = context.Space.Value;
+                    return context.CardInfo.DistanceTo(x, y) == distance;
 
                 //gamestate
                 case FriendlyTurn:  return Game.TurnPlayer == ThisCard.Controller;
                 case EnemyTurn:     return Game.TurnPlayer != ThisCard.Controller;
-                case FromField:     return context.Card.Location == CardLocation.Field;
-                case FromDeck:      return context.Card.Location == CardLocation.Deck;
+                case FromField:     return context.CardInfo.Location == CardLocation.Field;
+                case FromDeck:      return context.CardInfo.Location == CardLocation.Deck;
                 case NotFromEffect: return context.Stackable is Effect;
 
                 //max

--- a/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
@@ -70,6 +70,8 @@ namespace KompasCore.Effects
 
         public Trigger ThisTrigger { get; private set; }
 
+        private bool initialized = false;
+
         public void Initialize(Game game, GameCard thisCard, Trigger thisTrigger, Effect effect)
         {
             Game = game;
@@ -78,14 +80,17 @@ namespace KompasCore.Effects
             sourceRestriction = sourceRestriction ?? new CardRestriction();
             xRestriction = xRestriction ?? new XRestriction();
             spaceRestriction = spaceRestriction ?? new SpaceRestriction();
+            existsRestriction = existsRestriction ?? new CardRestriction();
 
             cardRestriction.Initialize(thisCard, effect.Controller, effect);
+            existsRestriction.Initialize(thisCard, effect.Controller, effect);
             xRestriction.Initialize(thisCard);
             spaceRestriction.Initialize(thisCard, effect.Controller, effect);
 
             this.ThisCard = thisCard;
             this.ThisTrigger = thisTrigger;
 
+            initialized = true;
             Debug.Log($"Initializing trigger for {thisCard?.CardName}. game is null? {game}");
         }
 
@@ -134,8 +139,17 @@ namespace KompasCore.Effects
             }
         }
 
+        private bool RestrictionValidDebug(string r, ActivationContext ctxt)
+        {
+            var success = RestrictionValid(r, ctxt);
+            if (!success) Debug.Log($"Trigger for {ThisCard.CardName} invalid at restriction {r} for {ctxt}");
+            return success;
+        }
+
         public bool Evaluate(ActivationContext context)
         {
+            if (!initialized) throw new System.ArgumentException("Trigger restriction not initialized!");
+
             try
             {
                 return triggerRestrictions.All(r => RestrictionValid(r, context));

--- a/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
@@ -21,6 +21,7 @@ namespace KompasCore.Effects
         public const string ThisCardFitsRestriction = "This Card Fits Restriction"; //100,
         public const string TriggererFitsRestriction = "Triggerer Fits Restriction"; //101,
         public const string TriggerersAugmentedCardFitsRestriction = "Triggerer's Augmented Card Fits Restriction";
+        public const string CardExists = "Card Exists";
 
         public const string AdjacentToRestriction = "Adjacent to Restriction";
         public const string CoordsFitRestriction = "Coords Fit Restriction"; //120,
@@ -56,6 +57,7 @@ namespace KompasCore.Effects
 
         public string[] triggerRestrictions = new string[0];
         public CardRestriction cardRestriction;
+        public CardRestriction existsRestriction;
         public XRestriction xRestriction;
         public SpaceRestriction spaceRestriction;
         public CardRestriction sourceRestriction;
@@ -95,6 +97,7 @@ namespace KompasCore.Effects
                 case ThisCardTriggered:        return context.Card == ThisCard;
                 case ThisCardInPlay:           return ThisCard.Location == CardLocation.Field;
                 case AugmentedCardTriggered:   return context.Card == ThisCard.AugmentedCard;
+                case CardExists:               return ThisCard.Game.Cards.Any(c => existsRestriction.Evaluate(c));
                 case ThisCardFitsRestriction:  return cardRestriction.Evaluate(ThisCard);
                 case TriggererFitsRestriction: return cardRestriction.Evaluate(context.Card);
                 case TriggerersAugmentedCardFitsRestriction: return cardRestriction.Evaluate(context.Card.AugmentedCard);

--- a/Assets/Scripts/Shared/HandController.cs
+++ b/Assets/Scripts/Shared/HandController.cs
@@ -1,6 +1,7 @@
 ﻿using KompasCore.Cards;
 using KompasCore.Effects;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace KompasCore.GameCore
@@ -16,7 +17,11 @@ namespace KompasCore.GameCore
 
         public virtual bool AddToHand(GameCard card, IStackable stackSrc = null)
         {
-            if (card == null) return false;
+            if (card == null)
+            {
+                Debug.LogError("Cannot add null card to hand");
+                return false;
+            }
             card.Remove(stackSrc);
             hand.Add(card);
             card.Location = CardLocation.Hand;
@@ -29,7 +34,11 @@ namespace KompasCore.GameCore
 
         public virtual bool RemoveFromHand(GameCard card)
         {
-            if (!hand.Contains(card)) return false;
+            if (!hand.Contains(card))
+            {
+                Debug.LogError($"Hand of \n{string.Join(", ", hand.Select(c => c.CardName))}\n doesn't contain {card}, can't remove it!");
+                return false;
+            }
 
             hand.Remove(card);
             SpreadOutCards();

--- a/Assets/Scripts/Shared/Networking/ServerNotifier.cs
+++ b/Assets/Scripts/Shared/Networking/ServerNotifier.cs
@@ -64,52 +64,52 @@ namespace KompasServer.Networking
         #endregion game stats
 
         #region card location
-        public void NotifyAttach(GameCard toAttach, int x, int y)
-            => SendToBothInverting(new AttachCardPacket(toAttach, x, y, invert: Player.index != 0), toAttach.KnownToEnemy);
+        public void NotifyAttach(GameCard toAttach, int x, int y, bool wasKnown)
+            => SendToBothInverting(new AttachCardPacket(toAttach, x, y, invert: Player.index != 0), wasKnown);
 
         /// <summary>
         /// Notifies that the Player corresponding to this notifier played a given card
         /// </summary>
-        public void NotifyPlay(GameCard toPlay, int x, int y)
+        public void NotifyPlay(GameCard toPlay, int x, int y, bool wasKnown)
         {
             //if this card is an augment, don't bother notifying about it. attach will take care of it.
             if (toPlay.CardType == 'A') return;
 
             //tell everyone to do it
             var p = new PlayCardPacket(toPlay.ID, toPlay.BaseJson, toPlay.ControllerIndex, x, y, invert: Player.index != 0);
-            var q = p.GetInversion(toPlay.KnownToEnemy);
+            var q = p.GetInversion(wasKnown);
             SendPackets(p, q);
         }
 
         public void NotifyMove(GameCard toMove, int x, int y)
             => SendToBothInverting(new MoveCardPacket(toMove.ID, x, y, invert: Player.index != 0));
 
-        public void NotifyDiscard(GameCard toDiscard)
-            => SendToBothInverting(new DiscardCardPacket(toDiscard, invert: Player.index != 0), toDiscard.KnownToEnemy);
+        public void NotifyDiscard(GameCard toDiscard, bool wasKnown)
+            => SendToBothInverting(new DiscardCardPacket(toDiscard, invert: Player.index != 0), wasKnown);
 
-        public void NotifyRehand(GameCard toRehand)
-            => SendToBothInverting(new RehandCardPacket(toRehand.ID), toRehand.KnownToEnemy);
+        public void NotifyRehand(GameCard toRehand, bool wasKnown)
+            => SendToBothInverting(new RehandCardPacket(toRehand.ID), wasKnown);
 
         public void NotifyDecrementHand() => SendPacket(new ChangeEnemyHandCountPacket(-1));
 
-        public void NotifyAnnhilate(GameCard toAnnhilate)
+        public void NotifyAnnhilate(GameCard toAnnhilate, bool wasKnown)
             => SendToBothInverting(new AnnihilateCardPacket(toAnnhilate.ID, toAnnhilate.BaseJson, toAnnhilate.ControllerIndex, invert: Player.index != 0), 
-                known: toAnnhilate.KnownToEnemy);
+                known: wasKnown);
 
-        public void NotifyTopdeck(GameCard card)
+        public void NotifyTopdeck(GameCard card, bool wasKnown)
             => SendToBothInverting(new TopdeckCardPacket(card.ID, card.OwnerIndex, invert: Player.index != 0), 
-                known: card.KnownToEnemy);
+                known: wasKnown);
 
-        public void NotifyBottomdeck(GameCard card)
+        public void NotifyBottomdeck(GameCard card, bool wasKnown)
             => SendToBothInverting(new BottomdeckCardPacket(card.ID, card.OwnerIndex, invert: Player.index != 0),
-                known: card.KnownToEnemy);
+                known: wasKnown);
 
-        public void NotifyReshuffle(GameCard toReshuffle)
+        public void NotifyReshuffle(GameCard toReshuffle, bool wasKnown)
             => SendToBothInverting(new ReshuffleCardPacket(toReshuffle.ID, toReshuffle.OwnerIndex, invert: Player.index != 0),
-                known: toReshuffle.KnownToEnemy);
+                known: wasKnown);
 
-        public void NotifyAddToDeck(GameCard added)
-            => SendToBothInverting(new AddCardPacket(added, invert: Player.index != 0), known: added.KnownToEnemy);
+        public void NotifyAddToDeck(GameCard added, bool wasKnown)
+            => SendToBothInverting(new AddCardPacket(added, invert: Player.index != 0), known: wasKnown);
 
         public void GetHandSizeChoices(int[] cardIds, string listRestrictionJson)
             => SendPacket(new GetHandSizeChoicesOrderPacket(cardIds, listRestrictionJson));

--- a/Assets/Scripts/Shared/Networking/ServerNotifier.cs
+++ b/Assets/Scripts/Shared/Networking/ServerNotifier.cs
@@ -16,7 +16,7 @@ namespace KompasServer.Networking
 
         public void SendPacket(Packet packet)
         {
-            // if (packet != null) Debug.Log($"Sending packet to {Player.index} with info {packet}");
+            //if (packet != null) Debug.Log($"Sending packet to {Player.index} with info {packet}");
             ServerNetworkCtrl.SendPacket(packet);
         }
 


### PR DESCRIPTION
Makes Teamwork and other Sportsball Plays a Vanishing spell. Also the trigger refactor so that triggers run only if their relevant action succeeds, which is necessary for these cards to work as intended.