### PR TITLE
Autodecline checkbox ignored

### DIFF
--- a/Assets/Scripts/Client/UI/ClientUIController.cs
+++ b/Assets/Scripts/Client/UI/ClientUIController.cs
@@ -103,6 +103,17 @@ namespace KompasClient.UI
             if (Input.GetKeyDown(KeyCode.Escape)) escapeMenuUICtrl.Enable();
         }
 
+        public override bool ShowInfoFor(GameCard card, bool refresh = false)
+        {
+            bool success = base.ShowInfoFor(card, refresh);
+            if (ShownCard != card || refresh)
+            {
+                cardInfoViewUICtrl.CurrShown = card;
+                cardInfoViewUICtrl.ShowForCurrShown();
+            }
+            return success;
+        }
+
         public bool ShowEffect(Effect eff) => eff.CanBeActivatedBy(clientGame.Players[0]);
 
         public override void SelectCard(GameCard card, Game.TargetMode targetMode, bool fromClick)

--- a/Assets/Scripts/Server/Effects/ServerEffectsController.cs
+++ b/Assets/Scripts/Server/Effects/ServerEffectsController.cs
@@ -211,8 +211,7 @@ namespace KompasServer.Effects
             lock (responseLock)
             {
                 var players = ServerGame.ServerPlayers
-                    .Where(player => !player.passedPriority &&
-                        ServerGame.Cards.Any(c => c.Effects.Any(e => e.CanBeActivatedBy(player))))
+                    .Where(player => !player.passedPriority)
                     .ToArray(); //call toArray so that we don't create the collection twice.
                 //remove the .ToArray() later if it turns out Linq is smart enough to only execute once, but I'm pretty sure it can't know.
 

--- a/Assets/Scripts/Shared/Effects/Restrictions/CardRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/CardRestriction.cs
@@ -140,6 +140,8 @@ namespace KompasCore.Effects
 
         public string blurb = "";
 
+        // Necessary because json doesn't let you have nice things, like constructors with arguments,
+        // so I need to make sure manually that I've bothered to set up relevant arguments.
         private bool initialized = false;
 
         public void Initialize(Subeffect subeff)

--- a/Assets/Scripts/Shared/Effects/Restrictions/SpaceRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/SpaceRestriction.cs
@@ -51,6 +51,8 @@ namespace KompasCore.Effects
         public string blurb = "";
         public bool mustBeEmpty = true;
 
+        // Necessary because json doesn't let you have nice things, like constructors with arguments,
+        // so I need to make sure manually that I've bothered to set up relevant arguments.
         private bool initialized = false;
 
         public void Initialize(GameCard source, Player controller, Effect effect)

--- a/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
@@ -70,6 +70,8 @@ namespace KompasCore.Effects
 
         public Trigger ThisTrigger { get; private set; }
 
+        // Necessary because json doesn't let you have nice things, like constructors with arguments,
+        // so I need to make sure manually that I've bothered to set up relevant arguments.
         private bool initialized = false;
 
         public void Initialize(Game game, GameCard thisCard, Trigger thisTrigger, Effect effect)

--- a/Assets/Scripts/Shared/UI/UIController.cs
+++ b/Assets/Scripts/Shared/UI/UIController.cs
@@ -59,7 +59,7 @@ namespace KompasCore.UI
         /// <param name="card">The card to show info for.</param>
         /// <param name="refresh">Whether to forcibly refresh all shown info of the card being shown</param>
         /// <returns><see langword="true"/> if the shown info was updated, <see langword="false"/> otherwise.</returns>
-        public bool ShowInfoFor(GameCard card, bool refresh = false)
+        public virtual bool ShowInfoFor(GameCard card, bool refresh = false)
         {
             if (ShownCard == card && !refresh) return false;
 

--- a/Assets/Scripts/Shared/UI/UIController.cs
+++ b/Assets/Scripts/Shared/UI/UIController.cs
@@ -71,7 +71,7 @@ namespace KompasCore.UI
             }
             else
             {
-                boardUICtrl.ShowForCard(card);
+                boardUICtrl.ShowForCard(card, forceRefresh: refresh);
                 return true;
             }
         }


### PR DESCRIPTION
Fix the autodecline checkbox being ignored by allowing players to hold priority whenever they want to.
Also refresh the shown board ui elements when other ui information is refreshed.