### PR TITLE
Fix Controllers being Null in Card Restriction

### DIFF
--- a/Assets/Resources/Card Jsons/The Intern.json
+++ b/Assets/Resources/Card Jsons/The Intern.json
@@ -8,7 +8,7 @@
 			{
 				"triggerCondition":"Draw",
 				"triggerRestriction":{
-					"triggerRestrictions":["This Card in Play","Max Per Stack"]
+					"triggerRestrictions":["This Card in Play","Max Per Stack","Controller Triggered"]
 				}
 			},
 			"subeffects":[

--- a/Assets/Resources/Card Jsons/shapers/Send Home.json
+++ b/Assets/Resources/Card Jsons/shapers/Send Home.json
@@ -34,7 +34,7 @@
 			"cardRestrictions":["Is Character","Enemy","Adjacent to Card Restriction"],
 			"adjacentCardRestriction":
 			{
-				"cardRestrictions":["Is Character","Friendly","Subtypes Include"],
+				"cardRestrictions":["Is Character","Subtypes Include"],
 				"subtypesInclude":["Shaper"]
 			}
 		}

--- a/Assets/Resources/Card Jsons/tarocco/Figurehead Knight.json
+++ b/Assets/Resources/Card Jsons/tarocco/Figurehead Knight.json
@@ -8,7 +8,7 @@
 			{
 				"triggerCondition":"Draw",
 				"triggerRestriction":{
-					"triggerRestrictions":["This Card in Play","Friendly Turn"]
+					"triggerRestrictions":["This Card in Play","Friendly Turn","Controller Triggered"]
 				}
 			},
 			"subeffects":[
@@ -27,7 +27,7 @@
 			{
 				"triggerCondition":"Draw",
 				"triggerRestriction":{
-					"triggerRestrictions":["This Card in Play","Enemy Turn"]
+					"triggerRestrictions":["This Card in Play","Enemy Turn","Controller Triggered"]
 				}
 			},
 			"subeffects":[

--- a/Assets/Resources/Card Jsons/tarocco/Figurehead Queen.json
+++ b/Assets/Resources/Card Jsons/tarocco/Figurehead Queen.json
@@ -8,7 +8,7 @@
 			{
 				"triggerCondition":"Draw",
 				"triggerRestriction":{
-					"triggerRestrictions":["This Card in Play"]
+					"triggerRestrictions":["This Card in Play","Controller Triggered"]
 				}
 			},
 			"subeffects":[

--- a/Assets/Scripts/Client/ClientHandSizeStackable.cs
+++ b/Assets/Scripts/Client/ClientHandSizeStackable.cs
@@ -12,9 +12,6 @@ namespace KompasClient.Effects {
         private readonly ClientPlayer clientController;
 
         public override Player Controller => clientController;
-        
-        //Hand size stackable doesn't come from any card
-        public override GameCard Source => default;
 
         public Sprite PrimarySprite => default;
         public CardController PrimaryCardController => default;

--- a/Assets/Scripts/Server/Effects/ServerHandSizeStackable.cs
+++ b/Assets/Scripts/Server/Effects/ServerHandSizeStackable.cs
@@ -12,8 +12,6 @@ namespace KompasServer.Effects
         public ServerPlayer ServerController { get; }
         public override Player Controller => ServerController;
 
-        public override GameCard Source => null;
-
         private readonly ServerGame serverGame;
 
         private bool awaitingChoices;

--- a/Assets/Scripts/Shared/CardRepository.cs
+++ b/Assets/Scripts/Shared/CardRepository.cs
@@ -130,13 +130,13 @@ public class CardRepository : MonoBehaviour
         try
         {
             card = JsonConvert.DeserializeObject<ServerSerializableCard>(cardJsons[cardName],
-                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto, MaxDepth = null, ReferenceLoopHandling = ReferenceLoopHandling.Serialize });
             effects.AddRange(card.effects);
             foreach(var s in card.keywords)
             {
                 var json = keywordJsons[s];
                 var eff = JsonConvert.DeserializeObject<ServerEffect>(json,
-                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto, MaxDepth = null, ReferenceLoopHandling = ReferenceLoopHandling.Serialize });
                 effects.Add(eff);
             }
         }
@@ -176,13 +176,13 @@ public class CardRepository : MonoBehaviour
         try
         {
             cardInfo = JsonConvert.DeserializeObject<ServerSerializableCard>(cardJsons[name],
-                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto, MaxDepth = null, ReferenceLoopHandling = ReferenceLoopHandling.Serialize });
             effects.AddRange(cardInfo.effects);
             foreach (var s in cardInfo.keywords)
             {
                 var keywordJson = keywordJsons[s];
                 var eff = JsonConvert.DeserializeObject<ServerEffect>(keywordJson,
-                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto, MaxDepth = null, ReferenceLoopHandling = ReferenceLoopHandling.Serialize });
                 effects.Add(eff);
             }
         }
@@ -223,14 +223,15 @@ public class CardRepository : MonoBehaviour
 
         try
         {
-            cardInfo = JsonUtility.FromJson<ClientSerializableCard>(json);
+            cardInfo = JsonConvert.DeserializeObject<ClientSerializableCard>(json,
+                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto, MaxDepth = null, ReferenceLoopHandling = ReferenceLoopHandling.Serialize });
             if (cardInfo.cardType != 'C') return null;
             effects.AddRange(cardInfo.effects);
             foreach (var s in cardInfo.keywords)
             {
                 var keywordJson = keywordJsons[s];
                 var eff = JsonConvert.DeserializeObject<ClientEffect>(keywordJson,
-                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto, MaxDepth = null, ReferenceLoopHandling = ReferenceLoopHandling.Serialize });
                 effects.Add(eff);
             }
         }
@@ -271,13 +272,14 @@ public class CardRepository : MonoBehaviour
 
         try
         {
-            cardInfo = JsonUtility.FromJson<ClientSerializableCard>(json);
+            cardInfo = JsonConvert.DeserializeObject<ClientSerializableCard>(json,
+                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto, MaxDepth = null, ReferenceLoopHandling = ReferenceLoopHandling.Serialize });
             effects.AddRange(cardInfo.effects);
             foreach (var s in cardInfo.keywords)
             {
                 var keywordJson = keywordJsons[s];
                 var eff = JsonConvert.DeserializeObject<ClientEffect>(keywordJson,
-                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+                    new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto, ReferenceLoopHandling = ReferenceLoopHandling.Serialize });
                 effects.Add(eff);
             }
         }

--- a/Assets/Scripts/Shared/Effects/Restrictions/ActivationRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/ActivationRestriction.cs
@@ -50,8 +50,8 @@ namespace KompasCore.Effects
                 if (activationRestrictionArray.Contains("Default"))
                     ActivationRestrictions.AddRange(DefaultRestrictions);
 
-                existsRestriction.Initialize(eff.Source, eff.Controller, eff);
-                thisCardRestriction.Initialize(eff.Source, eff.Controller, eff);
+                existsRestriction.Initialize(eff.Source, eff);
+                thisCardRestriction.Initialize(eff.Source, eff);
 
                 Debug.Log($"Initializing activation restriction for {Card.CardName} " +
                     $"with restrictions: {string.Join(", ", ActivationRestrictions)}");

--- a/Assets/Scripts/Shared/Effects/Restrictions/PlayRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/PlayRestriction.cs
@@ -93,7 +93,7 @@ namespace KompasCore.Effects
                 case EnemyTurn: return Card.Game.TurnPlayer != Card.Controller;
                 case OnBoardCardFriendlyOrAdjacent:
                     var cardThere = Card.Game.boardCtrl.GetCardAt(space);
-                    return cardThere != null 
+                    return cardThere != null && cardThere.CardType != 'A'
                         && (cardThere.Controller == Card.Controller || cardThere.AdjacentCards.Any(c => c.Controller == Card.Controller));
                 case OnCardFittingRestriction:
                     return onCardRestriction.Evaluate(Card.Game.boardCtrl.GetCardAt(space));

--- a/Assets/Scripts/Shared/Effects/Restrictions/PlayRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/PlayRestriction.cs
@@ -66,10 +66,9 @@ namespace KompasCore.Effects
             if (effectRestrictions.Contains(DefaultEffect)) effectRestrictions.AddRange(DefaultEffectRestrictions);
             if (effectRestrictions.Contains(AugEffect)) effectRestrictions.AddRange(AugmentEffectRestrictions);
 
-            onCardRestriction.Initialize(card, card.Controller, eff: default);
-            adjacentCardRestriction.Initialize(card, card.Controller, eff: default);
-
-            spaceRestriction.Initialize(card, card.Controller, effect: default);
+            onCardRestriction.Initialize(Card, eff: default);
+            adjacentCardRestriction.Initialize(Card, eff: default);
+            spaceRestriction.Initialize(Card, Card.Controller, effect: default);
             //Debug.Log($"Finished setting info for play restriction of card {card.CardName}");
         }
 
@@ -97,7 +96,6 @@ namespace KompasCore.Effects
                     return cardThere != null 
                         && (cardThere.Controller == Card.Controller || cardThere.AdjacentCards.Any(c => c.Controller == Card.Controller));
                 case OnCardFittingRestriction:
-                    onCardRestriction.Initialize(Card, player, null);
                     return onCardRestriction.Evaluate(Card.Game.boardCtrl.GetCardAt(space));
                 case NotNormally: return !normal;
                 case MustNormally: return normal;
@@ -113,18 +111,22 @@ namespace KompasCore.Effects
 
 
         public bool EvaluateNormalPlay(Space to, Player player, bool checkCanAffordCost = false)
-            => (!checkCanAffordCost || player.Pips >= Card.Cost) 
-            && normalRestrictions.All(r => RestrictionValid(r, to, player, true));
+        { 
+            return (!checkCanAffordCost || player.Pips >= Card.Cost)
+                && normalRestrictions.All(r => RestrictionValid(r, to, player, true));
+        }
 
         public bool EvaluateEffectPlay(Space to, Effect effect, Player controller, string[] ignoring = default)
-            => effectRestrictions
-            .Except(ignoring ?? new string[0])
-            .All(r => RestrictionValid(r, to, controller, false));
+        {
+            return effectRestrictions
+                .Except(ignoring ?? new string[0])
+                .All(r => RestrictionValid(r, to, controller, false));
+        }
       
         public bool RecommendedPlay(Space space, Player controller, bool normal)
         //=> recommendationRestrictions.All(r => RestrictionValid(r, x, y, controller, normal: normal));
         {
-            Debug.Log($"Checking {space} against recommendations {string.Join(", ", recommendationRestrictions)}");
+            //Debug.Log($"Checking {space} against recommendations {string.Join(", ", recommendationRestrictions)}");
             return recommendationRestrictions.All(r => RestrictionValid(r, space, controller, normal: normal));
         }
 

--- a/Assets/Scripts/Shared/Effects/Restrictions/SpaceRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/SpaceRestriction.cs
@@ -12,7 +12,7 @@ namespace KompasCore.Effects
     {
         public Subeffect Subeffect { get; private set; }
         public GameCard Source { get; private set; }
-        public Player Controller { get; private set; }
+        public Player Controller => Source.Controller;
         public Effect Effect { get; private set; }
 
         #region space restrictions
@@ -76,7 +76,6 @@ namespace KompasCore.Effects
         public void Initialize(GameCard source, Player controller, Effect effect)
         {
             Source = source;
-            Controller = controller;
             Effect = effect;
 
             adjacencyRestriction = adjacencyRestriction ?? new CardRestriction();
@@ -84,11 +83,11 @@ namespace KompasCore.Effects
             limitAdjacencyRestriction = limitAdjacencyRestriction ?? new CardRestriction();
             hereFitsRestriction = hereFitsRestriction ?? new CardRestriction();
 
-            adjacencyRestriction.Initialize(source, controller, effect);
-            connectednessRestriction.Initialize(source, controller, effect);
-            limitAdjacencyRestriction.Initialize(source, controller, effect);
-            hereFitsRestriction.Initialize(source, controller, effect);
-            inAOERestriction?.Initialize(source, controller, effect);
+            adjacencyRestriction.Initialize(source, effect);
+            connectednessRestriction.Initialize(source, effect);
+            limitAdjacencyRestriction.Initialize(source, effect);
+            hereFitsRestriction.Initialize(source, effect);
+            inAOERestriction?.Initialize(source, effect);
             distanceXRestriction?.Initialize(source);
             numberOfCardsInAOEOfRestriction?.Initialize(source);
 

--- a/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
+++ b/Assets/Scripts/Shared/Effects/Restrictions/TriggerRestriction.cs
@@ -82,6 +82,8 @@ namespace KompasCore.Effects
         public void Initialize(Game game, GameCard thisCard, Trigger thisTrigger, Effect effect)
         {
             Game = game;
+            ThisCard = thisCard;
+            ThisTrigger = thisTrigger;
 
             cardRestriction = cardRestriction ?? new CardRestriction();
             adjacencyRestriction = adjacencyRestriction ?? new CardRestriction();
@@ -90,14 +92,11 @@ namespace KompasCore.Effects
             spaceRestriction = spaceRestriction ?? new SpaceRestriction();
             existsRestriction = existsRestriction ?? new CardRestriction();
 
-            cardRestriction.Initialize(thisCard, effect.Controller, effect);
-            existsRestriction.Initialize(thisCard, effect.Controller, effect);
-            nowRestriction.Initialize(thisCard, effect.Controller, effect);
+            cardRestriction.Initialize(thisCard, effect);
+            existsRestriction.Initialize(thisCard, effect);
+            nowRestriction.Initialize(thisCard, effect);
             xRestriction.Initialize(thisCard);
-            spaceRestriction.Initialize(thisCard, effect.Controller, effect);
-
-            ThisCard = thisCard;
-            ThisTrigger = thisTrigger;
+            spaceRestriction.Initialize(thisCard, thisCard.Controller, effect);
 
             initialized = true;
             //Debug.Log($"Initializing trigger restriction for {thisCard?.CardName}. game is null? {game}");

--- a/Assets/Scripts/Shared/Player.cs
+++ b/Assets/Scripts/Shared/Player.cs
@@ -53,4 +53,9 @@ public abstract class Player : MonoBehaviour{
     }
 
     public Space SubjectiveCoords(Space space) => index == 0 ? space : space.Inverse;
+
+    public override string ToString()
+    {
+        return $"Player {index}";
+    }
 }

--- a/Assets/Scripts/Shared/Stack/HandSizeStackable.cs
+++ b/Assets/Scripts/Shared/Stack/HandSizeStackable.cs
@@ -11,7 +11,7 @@ namespace KompasCore.Effects
 
         public abstract Player Controller { get; }
 
-        public abstract GameCard Source { get; }
+        public GameCard Source => Controller.Avatar;
 
         public ListRestriction HandSizeListRestriction
         {
@@ -38,7 +38,7 @@ namespace KompasCore.Effects
                     CardRestriction.Friendly, CardRestriction.Hand
                     }
                 };
-                c.Initialize(Source, Controller, eff: default);
+                c.Initialize(Source, eff: default);
                 return c;
             }
         }


### PR DESCRIPTION
Make it invariant that the controller of a CardRestriction is always the controller of the card. If I implement taking control of cards and want for effects already on the stack to not be controlled with it, I'll need to implement something for that.